### PR TITLE
Allow login using ssh key and generalize a little

### DIFF
--- a/devices/debian.py
+++ b/devices/debian.py
@@ -18,7 +18,7 @@ class DebianBox(base.BaseDevice):
     A linux machine running an ssh server.
     '''
 
-    prompt = ['root\\@.*:.*#', '/ # ', ]
+    prompt = ['root\\@.*:.*#', '/ # ', ".*:~ #" ]
 
     def __init__(self,
                  name,
@@ -46,7 +46,7 @@ class DebianBox(base.BaseDevice):
         self.location = location
         cprint("%s device console = %s" % (name, colored(color, color)), None, attrs=['bold'])
         try:
-            i = self.expect(["yes/no", "assword:", "Linux"], timeout=30)
+            i = self.expect(["yes/no", "assword:", "Last login"], timeout=30)
         except pexpect.TIMEOUT as e:
             raise Exception("Unable to connect to %s." % name)
         except pexpect.EOF as e:
@@ -55,9 +55,8 @@ class DebianBox(base.BaseDevice):
             raise Exception("Unable to connect to %s." % name)
         if i == 0:
             self.sendline("yes")
-            self.expect("assword:")
-            self.sendline(password)
-        elif i == 1:
+            i = self.expect(["Last login", "assword:"])
+        if i == 1:
             self.sendline(password)
         else:
             pass


### PR DESCRIPTION
Making sure that connecting to LAN/WAN device continues even if nobody asks for
password (for example because we have a key on the machine - issue #8 ) and
also generalizing a little. Although it is debian.py, 'Last login' should be
more generic then Debian motd and adding one more prompt to catch openSUSE
default root prompt which is quite minimalistic and thus there is a good chance
it will catch other prompts of various linuxes as well.

Signed-off-by: Michal Hrusecky michal.hrusecky@nic.cz
