### PR TITLE
Possibility to run unattended

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -53,6 +53,7 @@ def parse():
                                      epilog=HELP_EPILOG)
     parser.add_argument('-l', '--list_tests', action='store_true', help='List available tests and exit')
     parser.add_argument('-i', '--inventory', action='store_true', help='List available boards and exit')
+    parser.add_argument('-y', '--batch', action='store_true', help='Run in unattended mode - do not spawn console on failed test')
     parser.add_argument('-k', '--kernel', metavar='', type=str, default=None, help='URL or file PATH of Kernel image to flash')
     parser.add_argument('-r', '--rootfs', metavar='', type=str, default=None, help='URL or file PATH of Rootfs image to flash')
     parser.add_argument('-m', '--meta_img_loc', metavar='', type=str, default=None, help='URL or file PATH to meta image to flash')
@@ -95,6 +96,8 @@ def parse():
         print(e)
         print('Unable to access/read Board Farm configuration\n%s' % boardfarm_config_location)
         sys.exit(1)
+
+    config.batch = args.batch
 
     if args.inventory:
         print("%11s  %15s  %5s  %25s  %25s  %s" % ('Name', 'Model', 'Auto', 'LAN', 'WAN', 'Notes'))

--- a/tests/rootfs_boot.py
+++ b/tests/rootfs_boot.py
@@ -10,7 +10,6 @@ import linux_boot
 import lib
 from devices import board, wan, lan, wlan, prompt
 
-
 class RootFSBootTest(linux_boot.LinuxBootTest):
     '''Flashed image and booted successfully.'''
 
@@ -155,7 +154,8 @@ class RootFSBootTest(linux_boot.LinuxBootTest):
             try:
                 board.sendline()
                 board.sendline()
-                board.interact()
+                if not self.config.batch:
+                    board.interact()
             except:
                 pass
             if self.reboot == True and self.reset_after_fail:


### PR DESCRIPTION
Sometimes it is needed to run tests non-interactively - for example in
automated testing. This commit adds an option to indicate it and also changes
rootfs_boot test (which everybody inherits from) to make it possible.

Signed-off-by: Michal Hrusecky michal.hrusecky@nic.cz
