### PR TITLE
Support current Debian

### DIFF
--- a/devices/debian.py
+++ b/devices/debian.py
@@ -171,7 +171,7 @@ class DebianBox(base.BaseDevice):
         self.sendline('EOF')
         self.expect(self.prompt)
         self.sendline('/etc/init.d/isc-dhcp-server start')
-        self.expect('Starting ISC DHCP server.*dhcpd.')
+        self.expect(['Starting ISC DHCP server.*dhcpd.', 'Starting isc-dhcp-server.*'])
         self.expect(self.prompt)
 
         # configure routing


### PR DESCRIPTION
New releases of Debian use systemd and thus output when starting ISC DHCP looks
different. Updating it to match.

Signed-off-by: Michal Hrusecky michal.hrusecky@nic.cz
