### PR TITLE
Adding support for local serial port access. Closes #4

### DIFF
--- a/devices/connection_decider.py
+++ b/devices/connection_decider.py
@@ -3,16 +3,13 @@ import local_serial_connection
 
 def connection(conn_type, device, **kwargs):
     '''
-    Depending on the given model, return an object of the appropriate class type.
-
-    Different boards are flashed with different commands, have
-    different memory addresses, and must be handled differently.
+    Depending on the given connection type return an object of the appropriate class type.
     '''
     if conn_type in ("ser2net"):
         return ser2net_connection.Ser2NetConnection(device=device,**kwargs)
 
     if conn_type in ("local_serial"):
-        return local_serial_connection.LocalSerialConnection(device=device,**kwargs)
+        return local_serial_connection.LocalSerialConnection(device=device**kwargs)
 
     # Default for all other models
     print("\nWARNING: Unknown connection type  '%s'." % type)

--- a/devices/connection_decider.py
+++ b/devices/connection_decider.py
@@ -1,0 +1,21 @@
+import ser2net_connection
+import local_serial_connection
+
+def connection(conn_type, device, **kwargs):
+    '''
+    Depending on the given model, return an object of the appropriate class type.
+
+    Different boards are flashed with different commands, have
+    different memory addresses, and must be handled differently.
+    '''
+    if conn_type in ("ser2net"):
+        return ser2net_connection.Ser2NetConnection(device=device,**kwargs)
+
+    if conn_type in ("local_serial"):
+        return local_serial_connection.LocalSerialConnection(device=device,**kwargs)
+
+    # Default for all other models
+    print("\nWARNING: Unknown connection type  '%s'." % type)
+    print("Please check spelling, or write an appropriate class "
+          "to handle that kind of board.")
+    return ser2net_connection.Ser2NetConnection(**kwargs)

--- a/devices/local_serial_connection.py
+++ b/devices/local_serial_connection.py
@@ -1,0 +1,23 @@
+import pexpect
+
+class LocalSerialConnection():
+    '''
+    To use, set conn_cmd in your json to "cu -s <port_speed> -l <path_to_serialport>"
+    and set connection_type to "local_serial"
+
+    '''
+    def __init__(self, device=None, conn_cmd=None, **kwargs):
+        self.device = device
+        self.conn_cmd = conn_cmd
+
+    def connect(self):
+        pexpect.spawn.__init__(self.device,
+                           command='/bin/bash',
+                           args=['-c', self.conn_cmd])
+        try:
+            result = self.device.expect(".*Connected.*")
+        except pexpect.EOF as e:
+            raise Exception("Board is in use (connection refused).")
+
+    def close():
+        self.device.sendline("~.")

--- a/devices/openwrt_router.py
+++ b/devices/openwrt_router.py
@@ -49,19 +49,17 @@ class OpenWrtRouter(base.BaseDevice):
                  password='bigfoot1',
                  web_proxy=None,
                  tftp_server=None,
+                 connection_type=None,
                  **kwargs):
-        pexpect.spawn.__init__(self,
-                               command='/bin/bash',
-                               args=['-c', conn_cmd],
-                               **kwargs)
-        try:
-            result = self.expect(["assword:", "ser2net", "OpenGear Serial Server"])
-        except pexpect.EOF as e:
-            raise Exception("Board is in use (connection refused).")
-        if result == 0:
-            self.sendline(password)
-            self.expect("OpenGear Serial Server")
+
+
+        if connection_type is None:
+            connection_type = "ser2net"
+            
         self.logfile_read = output
+        self.connection = connection_decider.connection(connection_type, device=self, **kwargs)
+        self.connection.connect()
+
         self.power = power.get_power_device(power_ip, power_outlet)
         self.model = model
         self.web_proxy = web_proxy

--- a/docs/BOARD_FARM.md
+++ b/docs/BOARD_FARM.md
@@ -25,7 +25,7 @@ Ingredients
 The smallest board farm requires:
 
 * 1 board (e.g. a router).
-* 1 console server.
+* 1 console server. (or local serial connection (see below)
 * 1 network-controlled power switch.
 * 2 computers each with 2 network interfaces - Preferably Debian Linux. Can be small Raspberry PI computers, or more powerful computers (to acheive gigabit throughput).
 * Several ethernet cables, and serial connector for the board.
@@ -42,7 +42,7 @@ Here we assume the "board" you wish to test is a router.
 Ethernet connections:
 
     Local Network <---> eth0-Computer-eth1 <---> LAN-Router-WAN <---> eth1-Computer-eth0 <---> Local Network
-    
+
 Serial Connections:
 
     Console server <---> Router
@@ -106,3 +106,22 @@ Where:
 * `conn_cmd` is the command to run to connect to the board
 * `lan_device` and `wan_device` are the devices connected to the board (must have ssh server)
 * `powerip` and `powerport` are the network-control power unit and outlet to reset the board
+
+Using a local serial port (i.e. no console server)
+----------------------
+Boardfarm also supports using a local serial port. This is useful when you have
+your PC connected directly to the device under test. To do so, you'd modify your
+board farm JSON config file as follows:
+
+* add `"connection_type": "local_serial"` to your board entry
+* replace the current `conn_cmd` element with with `"conn_cmd": "cu -l <port> -s <speed>"` in your board entry
+
+Where:
+* `port` is the path to your serial port. One example would be `/dev/ttyUSB0`.
+* `speed` is the baud rate for the serial port connection. One example would be `115200`.
+
+Additionally, you must install the `cu` program on your connecting computer. If running,
+a Debian based system, you would run:
+```
+apt-get install cu
+```


### PR DESCRIPTION
Local serial port access can be done now using `cu`. It'd be nice to do this entirely in python but that'd require more reworking of the code.
