### PR TITLE
Documenting cu package name for openSUSE

### DIFF
--- a/docs/BOARD_FARM.md
+++ b/docs/BOARD_FARM.md
@@ -125,3 +125,7 @@ a Debian based system, you would run:
 ```
 apt-get install cu
 ```
+If running openSUSE, you would run:
+```
+zypper in uucp
+```


### PR DESCRIPTION
As 'cu' binary is part of the package with different name and it is not that
obvious what to install on openSUSE, making it part of documentation.

Signed-off-by: Michal Hrusecky michal.hrusecky@nic.cz
