### PR TITLE
Username, password, port settable via config

### DIFF
--- a/bft
+++ b/bft
@@ -67,15 +67,30 @@ def main():
             if config.board.get('wan_device'):
                 config.wan = debian.DebianBox(config.board.get('wan_device'),
                                               color='cyan', reboot=config.reboot_vms,
-                                              location=config.board.get('location'))
+                                              location=config.board.get('location'),
+                                              username=config.board.get('wan_username', "root"),
+                                              password=config.board.get('wan_password', "bigfoot1"),
+                                              port=config.board.get('wan_port', "22"))
             if config.board.get('lan_device'):
-                config.lan = debian.DebianBox(config.board.get('lan_device'), color='blue', reboot=config.reboot_vms)
+                config.lan = debian.DebianBox(config.board.get('lan_device'), color='blue', reboot=config.reboot_vms,
+                                            username=config.board.get('lan_username', "root"),
+                                            password=config.board.get('lan_password', "bigfoot1"),
+                                            port=config.board.get('lan_port', "22"))
             if config.board.get('wlan_device'):
-                config.wlan = debian.DebianBox(config.board.get('wlan_device'), color='green', reboot=config.reboot_vms)
+                config.wlan = debian.DebianBox(config.board.get('wlan_device'), color='green', reboot=config.reboot_vms,
+                                            username=config.board.get('wlan_username', "root"),
+                                            password=config.board.get('wlan_password', "bigfoot1"),
+                                            port=config.board.get('wlan_port', "22"))
             if config.board.get('5g_device'):
-                config.wlan5g = debian.DebianBox(config.board.get('5g_device'), color='grey', reboot=config.reboot_vms)
+                config.wlan5g = debian.DebianBox(config.board.get('5g_device'), color='grey', reboot=config.reboot_vms,
+                                                username=config.board.get('5g_username', "root"),
+                                                password=config.board.get('5g_password', "bigfoot1"),
+                                                port=config.board.get('5g_port', "22"))
             if config.board.get('2g_device'):
-                config.wlan2g = debian.DebianBox(config.board.get('2g_device'), color='magenta', reboot=config.reboot_vms)
+                config.wlan2g = debian.DebianBox(config.board.get('2g_device'), color='magenta', reboot=config.reboot_vms,
+                                                username=config.board.get('2g_username', "root"),
+                                                password=config.board.get('2g_password', "bigfoot1"),
+                                                port=config.board.get('2g_port', "22"))
 
         except Exception as e:
             print(e)

--- a/devices/debian.py
+++ b/devices/debian.py
@@ -23,10 +23,10 @@ class DebianBox(base.BaseDevice):
     def __init__(self,
                  name,
                  color,
-                 output=sys.stdout,
                  username,
                  password,
                  port,
+                 output=sys.stdout,
                  reboot=False,
                  location=None):
         if name is None:

--- a/devices/debian.py
+++ b/devices/debian.py
@@ -24,9 +24,9 @@ class DebianBox(base.BaseDevice):
                  name,
                  color,
                  output=sys.stdout,
-                 username='root',
-                 password='bigfoot1',
-                 port="22",
+                 username,
+                 password,
+                 port,
                  reboot=False,
                  location=None):
         if name is None:
@@ -317,7 +317,10 @@ class DebianBox(base.BaseDevice):
 if __name__ == '__main__':
     # Example use
     dev = DebianBox('10.0.0.173',
-                    'blue')
+                    'blue',
+                    username="root",
+                    password="bigfoot1",
+                    port="22")
     dev.sendline('echo Hello')
     dev.expect('Hello', timeout=4)
     dev.expect(dev.prompt)


### PR DESCRIPTION
A resubmission of #31. Now the user, pass and port defaults are taken out of debian.py and put into bft. Probably a better way to handle this.

Note: Hasn't been tested as I can't test this with my current system.
