### PR TITLE
Set tftp username and password from config

### DIFF
--- a/bft
+++ b/bft
@@ -55,6 +55,8 @@ def main():
                                                  power_outlet=config.board.get('powerport', None),
                                                  web_proxy=config.board.get('lan_device', None),
                                                  tftp_server=config.board.get('wan_device', None),
+                                                 tftp_username=config.board.get('wan_username', 'root'),
+                                                 tftp_password=config.board.get('wan_password', 'bigfoot1'),
                                                  connection_type=config.board.get('connection_type', None),
                                                  power_username=config.board.get('power_username', None),
                                                  power_password=config.board.get('power_password', None))

--- a/devices/openwrt_router.py
+++ b/devices/openwrt_router.py
@@ -50,6 +50,8 @@ class OpenWrtRouter(base.BaseDevice):
                  password='bigfoot1',
                  web_proxy=None,
                  tftp_server=None,
+                 tftp_username=None,
+                 tftp_password=None,
                  connection_type=None,
                  power_username=None,
                  power_password=None,
@@ -68,6 +70,10 @@ class OpenWrtRouter(base.BaseDevice):
         self.web_proxy = web_proxy
         if tftp_server:
             self.tftp_server = socket.gethostbyname(tftp_server)
+            if tftp_username:
+                self.tftp_username = tftp_username
+            if tftp_password:
+                self.tftp_password = tftp_password
         else:
             self.tftp_server = None
         self.lan_iface = "eth1"
@@ -170,13 +176,13 @@ class OpenWrtRouter(base.BaseDevice):
                 self.expect(self.uprompt)
         raise Exception("TFTP failed, try rebooting the board.")
 
-    def prepare_file(self, fname, username='root', password='bigfoot1'):
+    def prepare_file(self, fname):
         '''Copy file to tftp server, so that it it available to tftp
         to the board itself.'''
         if fname.startswith("http://") or fname.startswith("https://"):
-            return common.download_from_web(fname, self.tftp_server, username, password)
+            return common.download_from_web(fname, self.tftp_server, self.tftp_username, self.tftp_password)
         else:
-            return common.scp_to_tftp_server(os.path.abspath(fname), self.tftp_server, username, password)
+            return common.scp_to_tftp_server(os.path.abspath(fname), self.tftp_server, self.tftp_username, self.tftp_password)
 
     def install_package(self, fname):
         '''Install OpenWrt package (opkg).'''


### PR DESCRIPTION
Right now, the username and password used for prepare_file in openwrt_router.py has [defaults](https://github.com/qca/boardfarm/compare/master...ericschultz:tftp-username-config?expand=1#diff-3982e59e120492483da762f182bfdf50L173) which can't be overridden from config. Additionally, none of the calls to prepare_file in boardfarm actually use a different username and password.

Give these situations, I've submitted the pull requests with the following changes:
- set the tftp username and password to the wan username and password since, in all the tests to date, they've been the same thing
- pass the tftp username and password into openwrt_router
- remove the arguments to prepare_file for the username and password and default to the tftp username and password passed into openwrt_router

How do people feel about this? Does this break anyone's use cases?
