### PR TITLE
Allow to reference previous test-suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ class iPerfTest(rootfs_boot.RootFSBootTest):
 Test Suites
 -----------
 
-A test suite is a list of test cases.  Several are already defined in in the file `testsuites.cfg`. For example:
+A test suite is a list of test cases. Several are already defined in in the file `testsuites.cfg`. For example:
 
 ```
 [basic]
@@ -162,6 +162,23 @@ OpkgList
 KernelModules
 MemoryUse
 InterfacesShow
+LanDevPingRouter
+RouterPingWanDev
+LanDevPingWanDev
+```
+
+Optionally, test suite may reference (using `@`) any other previously defined test suites to include all the test cases it contains. For example:
+```
+[basic-offline]
+RootFSBootTest
+OpenwrtVersion
+OpkgList
+KernelModules
+MemoryUse
+InterfacesShow
+
+[basic]
+@basic-offline
 LanDevPingRouter
 RouterPingWanDev
 LanDevPingWanDev

--- a/devices/configreader.py
+++ b/devices/configreader.py
@@ -25,11 +25,15 @@ class TestsuiteConfigReader(object):
       [testsuiteB]
       test7
       test2
+      [testsuiteC]
+      @testsuiteB
+      test3
 
     And from that, create dictionary like:
 
       {'testsuiteA' : [test1, test2, test1, test2, ...]
        'testsuiteB' : [test7, test2, ...]
+       'testsuiteC' : [test7, test2, test3, ...]
       }
     '''
 
@@ -65,6 +69,10 @@ class TestsuiteConfigReader(object):
                     current_section = re.search('\[(.*)\]', line).group(1)
                     if current_section not in self.section:
                         self.section[current_section] = []
+                if '@' in line:
+                    ref_section = re.search('@(.*)', line).group(1)
+                    if ref_section in self.section:
+                        self.section[current_section] = self.section[current_section] + self.section[ref_section]
                 elif re.match('\w+', line):
                     if current_section:
                         self.section[current_section].append(line)

--- a/testsuites.cfg
+++ b/testsuites.cfg
@@ -6,29 +6,32 @@
 [connect]
 Interact
 
-[daily]
+[basic]
 RootFSBootTest
 OpenwrtVersion
-Uname
 OpkgList
 KernelModules
 MemoryUse
 InterfacesShow
-UciShow
 LanDevPingRouter
 RouterPingWanDev
 LanDevPingWanDev
 Webserver_Download
 UciShowWireless
-WiFiMemUse
 WiFiOnOffCycle5
 RestartNetwork
 iPerfBiDirTest
-ConnectionRate
 Set_IPv6_Addresses
 LanDevPing6Router
 LanDevPing6WanDev
 iPerfBiDirTestIPV6
+
+[daily]
+@basic
+Uname
+UciShow
+WiFiMemUse
+ConnectionRate
 PerfPerPktTest
 ProcVmstat
 
@@ -74,25 +77,5 @@ iPerfBiDirTest
 iPerfUDPReverseTest
 iPerfUDPBiDirTest
 BridgedMode
-
-[basic]
-RootFSBootTest
-OpenwrtVersion
-OpkgList
-KernelModules
-MemoryUse
-InterfacesShow
-LanDevPingRouter
-RouterPingWanDev
-LanDevPingWanDev
-Webserver_Download
-UciShowWireless
-WiFiOnOffCycle5
-RestartNetwork
-iPerfBiDirTest
-Set_IPv6_Addresses
-LanDevPing6Router
-LanDevPing6WanDev
-iPerfBiDirTestIPV6
 
 


### PR DESCRIPTION
One possible course of action is to make bundles of tests and then use those
bundles to compose test runs. It also makes sense to have a short simple test
suite, but once in the while extend it by adding more tests to it.

So adding an option to include test-suite in another test-suite. Apart from
names of the test, one can now reference whole other test-suite (given it was
processed already) using @test-suite notation.

Signed-off-by: Michal Hrusecky michal.hrusecky@nic.cz
