### PR TITLE
Add a limit on the search window for UciShow

### DIFF
--- a/tests/status.py
+++ b/tests/status.py
@@ -49,7 +49,7 @@ class UciShow(rootfs_boot.RootFSBootTest):
         num_files = int(board.match.group(1))
         board.expect(prompt)
         board.sendline('uci show')
-        board.expect(prompt)
+        board.expect(prompt, searchwindowsize=50)
         self.result_message = 'Dumped all current uci settings from %s files in /etc/config/.' % num_files
 
 class DhcpLeaseCheck(rootfs_boot.RootFSBootTest):


### PR DESCRIPTION
When .expect is run, pexpect searches the entire buffer after every character is read in to see if there's any of the regex's match. In the case of the `uci show` this buffer is pretty large. Additionally, there are 5 or so prompt regex's in the `prompt` variable. Because of the buffer size, this bogs down low-powered CPUs in particular. Since since the prompts are always near the end, we don't really need to search the entire buffer, just the last few characters of it. This change makes pexpect look for the prompts in the last 50 characters read in for the `UciShow` test. I don't see a situation where the prompt would be too long for 50 characters in this case but it's possible I'm overlooking something.
