### PR TITLE
Support for non-root test users

### DIFF
--- a/bft
+++ b/bft
@@ -33,7 +33,7 @@ def main():
     import devices
     from termcolor import colored
     from library import print_bold
-    from devices import board_decider, debian, logstash, elasticlogger
+    from devices import board_decider, debian_decider, logstash, elasticlogger
 
     # Connect to any board in list
     connected_to_board = False
@@ -69,29 +69,29 @@ def main():
             config.wlan2g = None
 
             if config.board.get('wan_device'):
-                config.wan = debian.DebianBox(config.board.get('wan_device'),
+                config.wan = debian_decider.debian(config.board.get('wan_device'),
                                               color='cyan', reboot=config.reboot_vms,
                                               location=config.board.get('location'),
                                               username=config.board.get('wan_username', "root"),
                                               password=config.board.get('wan_password', "bigfoot1"),
                                               port=config.board.get('wan_port', "22"))
             if config.board.get('lan_device'):
-                config.lan = debian.DebianBox(config.board.get('lan_device'), color='blue', reboot=config.reboot_vms,
+                config.lan = debian_decider.debian(config.board.get('lan_device'), color='blue', reboot=config.reboot_vms,
                                             username=config.board.get('lan_username', "root"),
                                             password=config.board.get('lan_password', "bigfoot1"),
                                             port=config.board.get('lan_port', "22"))
             if config.board.get('wlan_device'):
-                config.wlan = debian.DebianBox(config.board.get('wlan_device'), color='green', reboot=config.reboot_vms,
+                config.wlan = debian_decider.debian(config.board.get('wlan_device'), color='green', reboot=config.reboot_vms,
                                             username=config.board.get('wlan_username', "root"),
                                             password=config.board.get('wlan_password', "bigfoot1"),
                                             port=config.board.get('wlan_port', "22"))
             if config.board.get('5g_device'):
-                config.wlan5g = debian.DebianBox(config.board.get('5g_device'), color='grey', reboot=config.reboot_vms,
+                config.wlan5g = debian_decider.debian(config.board.get('5g_device'), color='grey', reboot=config.reboot_vms,
                                                 username=config.board.get('5g_username', "root"),
                                                 password=config.board.get('5g_password', "bigfoot1"),
                                                 port=config.board.get('5g_port', "22"))
             if config.board.get('2g_device'):
-                config.wlan2g = debian.DebianBox(config.board.get('2g_device'), color='magenta', reboot=config.reboot_vms,
+                config.wlan2g = debian_decider.debian(config.board.get('2g_device'), color='magenta', reboot=config.reboot_vms,
                                                 username=config.board.get('2g_username', "root"),
                                                 password=config.board.get('2g_password', "bigfoot1"),
                                                 port=config.board.get('2g_port', "22"))

--- a/bin/ip_neigh_flush
+++ b/bin/ip_neigh_flush
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DIR="$( cd -P "$DIR/../devices" && pwd )"
+
+python $DIR/local_debian_runner.py ip_neigh_flush 1>&2 | tee /tmp/ip_neigh_flush.log
+
+exit 0

--- a/bin/restart_tftp_server
+++ b/bin/restart_tftp_server
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DIR="$( cd -P "$DIR/../devices" && pwd )"
+
+python $DIR/local_debian_runner.py restart_tftp_server 1>&2  | tee /tmp/restart_tftp_server.log
+
+exit 0

--- a/bin/setup_lan
+++ b/bin/setup_lan
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -x
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DIR="$( cd -P "$DIR/../devices" && pwd )"
+
+python $DIR/local_debian_runner.py init_lan 2>&1 | tee /tmp/setup_lan.log
+exit 0

--- a/bin/setup_wan
+++ b/bin/setup_wan
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -x
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DIR="$( cd -P "$DIR/../devices" && pwd )"
+
+python $DIR/local_debian_runner.py init_wan 2>&1 | tee /tmp/setup_wan.log
+exit 0

--- a/bin/start_lan_client
+++ b/bin/start_lan_client
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+DIR="$( cd -P "$DIR/../devices" && pwd )"
+
+python $DIR/local_debian_runner.py start_lan_client 1>&2 | tee /tmp/start_lan_client
+
+exit 0

--- a/conf/boardfarm_cron
+++ b/conf/boardfarm_cron
@@ -1,0 +1,1 @@
+*/10 * * * * root systemctl start dhclient.eth0

--- a/conf/dhclient.eth0.service
+++ b/conf/dhclient.eth0.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=dhclient on eth0
+Wants=network.target
+Before=network.target
+
+[Service]
+ExecStart=/sbin/dhclient -d -v eth0
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/lan_setup.service
+++ b/conf/lan_setup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Startup Script for non-root Boardfarm LAN setup
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/setup_lan
+Type=forking
+
+[Install]
+WantedBy=multi-user.target

--- a/conf/testing_sudoers
+++ b/conf/testing_sudoers
@@ -1,0 +1,2 @@
+Cmnd_Alias TESTING_CMDS = /sbin/reboot, /usr/bin/start_lan_client, /usr/bin/ip_neigh_flush, /usr/bin/turn_on_pppoe, /usr/bin/restart_tftp_server, /usr/bin/stop_lan_client
+__username__ ALL=(ALL) NOPASSWD: TESTING_CMDS

--- a/conf/wan_setup.service
+++ b/conf/wan_setup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Startup Script for non-root Boardfarm WAN setup
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/setup_wan
+Type=forking
+
+[Install]
+WantedBy=multi-user.target

--- a/devices/debian_decider.py
+++ b/devices/debian_decider.py
@@ -1,0 +1,23 @@
+import debian
+import non_root_debian
+import sys
+
+def debian(name, color,
+                    username,
+                    password,
+                    port,
+                    output=sys.stdout,
+                    reboot=False,
+                    location=None):
+    '''
+    This function controls which class to use for your debian boxes: DebianBox
+    when your username is root and NotRootDebianBox for other usernames.
+    '''
+    if (username is 'root'):
+        return debian.DebianBox(name=name, color=color, username=username,
+                                password=password, port=port, output=output,
+                                reboot=reboot, location=location)
+    else:
+        return non_root_debian.NonRootDebianBox(name=name, color=color, username=username,
+                                                password=password, port=port, output=output,
+                                                reboot=reboot, location=location)

--- a/devices/local_debian_runner.py
+++ b/devices/local_debian_runner.py
@@ -1,0 +1,74 @@
+import base
+import pexpect
+import debian
+import sys
+import argparse
+from termcolor import colored, cprint
+
+class LocalDebianRunner(debian.DebianBox):
+    prompt = ['root\\@.*:.*#', '/ # ', ".*:~ #", ".*:~.*\\$", ".*\\@.*:.*\\$" ]
+
+    def __init__(self,
+                 color,
+                 output=sys.stdout,
+                 reboot=False,
+                 location=None
+                 ):
+
+        pexpect.spawn.__init__(self,
+                               command="bash")
+
+        self.color = color
+        self.output = output
+        self.location = location
+        cprint("%s device console = %s" % ("local device", colored(color, color)), None, attrs=['bold'])
+        self.expect(self.prompt)
+
+        if reboot:
+            self.reset()
+
+        self.logfile_read = output
+
+    def setup_as_wan_gateway(self):
+        debian.DebianBox.setup_as_wan_gateway(self)
+    def setup_as_lan_device(self):
+        debian.DebianBox.setup_as_lan_device(self)
+    def start_lan_client(self):
+        debian.DebianBox.start_lan_client(self)
+
+    def restart_tftp_server(self):
+        debian.DebianBox.restart_tftp_server(self)
+
+    def turn_on_pppoe(self):
+        debian.DebianBox.turn_on_pppoe(self)
+    def ip_neigh_flush(self):
+        debian.DebianBox.ip_neigh_flush(self)
+
+    def stop_lan_client(self):
+        debian.DebianBox.stop_lan_client(self)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=['init_wan', 'init_lan', 'start_lan_client',
+                'restart_tftp_server', 'turn_on_pppoe', 'ip_neigh_flush', 'stop_lan_client'])
+
+    args = parser.parse_args()
+    dev = LocalDebianRunner('cyan')
+
+    if args.action == "init_wan":
+        dev.setup_as_wan_gateway()
+    elif args.action == 'init_lan':
+        dev.setup_as_lan_device()
+    elif args.action == 'start_lan_client':
+        dev.start_lan_client()
+    elif args.action == 'restart_tftp_server':
+        dev.restart_tftp_server()
+    elif args.action == 'ip_neigh_flush':
+        dev.ip_neigh_flush()
+    elif args.action == 'turn_on_pppoe':
+        dev.turn_on_pppoe()
+    elif args.action == 'stop_lan_client':
+        dev.stop_lan_client()
+    else:
+        parser.print_help()

--- a/devices/local_debian_setup.py
+++ b/devices/local_debian_setup.py
@@ -1,0 +1,74 @@
+import base
+import pexpect
+import debian
+import sys
+import argparse
+from termcolor import colored, cprint
+
+class LocalDebianRunner(debian.DebianBox):
+    prompt = ['root\\@.*:.*#', '/ # ', ".*:~ #", ".*:~.*\\$", ".*\\@.*:.*\\$" ]
+
+    def __init__(self,
+                 color,
+                 output=sys.stdout,
+                 reboot=False,
+                 location=None
+                 ):
+
+        pexpect.spawn.__init__(self,
+                               command="bash")
+
+        self.color = color
+        self.output = output
+        self.location = location
+        cprint("%s device console = %s" % ("local device", colored(color, color)), None, attrs=['bold'])
+        self.expect(self.prompt)
+
+        if reboot:
+            self.reset()
+
+        self.logfile_read = output
+
+    def setup_as_wan_gateway(self):
+        debian.DebianBox.setup_as_wan_gateway(self)
+    def setup_as_lan_device(self):
+        debian.DebianBox.setup_as_lan_device(self)
+    def start_lan_client(self):
+        debian.DebianBox.start_lan_client(self)
+
+    def restart_tftp_server(self):
+        debian.DebianBox.restart_tftp_server(self)
+
+    def turn_on_pppoe(self):
+        debian.DebianBox.turn_on_pppoe(self)
+    def ip_neigh_flush(self):
+        debian.DebianBox.ip_neigh_flush(self)
+
+    def stop_lan_client(self):
+        debian.DebianBox.stop_lan_client(self)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=['init_wan', 'init_lan', 'start_lan_client',
+                'restart_tftp_server', 'turn_on_pppoe', 'ip_neigh_flush', 'stop_lan_client'])
+
+    args = parser.parse_args()
+    dev = LocalDebianRunner('cyan')
+
+    if args.action == "init_wan":
+        dev.setup_as_wan_gateway()
+    elif args.action == 'init_lan':
+        dev.setup_as_lan_device()
+    elif args.action == 'start_lan_client':
+        dev.start_lan_client()
+    elif args.action == 'restart_tftp_server':
+        dev.restart_tftp_server()
+    elif args.action == 'ip_neigh_flush':
+        dev.ip_neigh_flush()
+    elif args.action == 'turn_on_pppoe':
+        dev.turn_on_pppoe()
+    elif args.action == 'stop_lan_client':
+        dev.stop_lan_client()
+    else:
+        parser.print_help()

--- a/devices/non_root_debian.py
+++ b/devices/non_root_debian.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2015
+#
+# All rights reserved.
+#
+# This file is distributed under the Clear BSD license.
+# The full text can be found in LICENSE in the root directory.
+
+import sys
+import time
+import pexpect
+import base
+import argparse
+
+from termcolor import colored, cprint
+
+
+class NonRootDebianBox(base.BaseDevice):
+    '''
+    A linux machine running an ssh server, not running as root.
+
+    This class is different from DebianBox in some unique ways. First, most of
+    the function calls here call shell scripts via sudo. Those shell
+    scripts, not included, call into local_debian_runner.py on the actual box itself.
+    This requires a copy of Boardfarm on your debian box.
+    '''
+
+    prompt = ['root\\@.*:.*#', '/ # ', ".*:~ #", ".*:~.*\\$", ".*\\@.*:.*\\$" ]
+
+    def __init__(self,
+                 name,
+                 color,
+                 username,
+                 password,
+                 port,
+                 output=sys.stdout,
+                 reboot=False,
+                 location=None
+                 ):
+        if name is None:
+            return
+        pexpect.spawn.__init__(self,
+                               command="ssh",
+                               args=['%s@%s' % (username, name),
+                                     '-p', port,
+                                     '-o', 'StrictHostKeyChecking=no',
+                                     '-o', 'UserKnownHostsFile=/dev/null'])
+        self.name = name
+        self.color = color
+        self.output = output
+        self.username = username
+        self.password = password
+        self.port = port
+        self.location = location
+        cprint("%s device console = %s" % (name, colored(color, color)), None, attrs=['bold'])
+        try:
+            i = self.expect(["yes/no", "assword:", "Last login"], timeout=30)
+        except pexpect.TIMEOUT as e:
+            raise Exception("Unable to connect to %s." % name)
+        except pexpect.EOF as e:
+            if hasattr(self, "before"):
+                print(self.before)
+            raise Exception("Unable to connect to %s." % name)
+        if i == 0:
+            self.sendline("yes")
+            i = self.expect(["Last login", "assword:"])
+        if i == 1:
+            self.sendline(password)
+        else:
+            pass
+        self.expect(self.prompt)
+
+        if reboot:
+            self.reset()
+
+        self.logfile_read = output
+
+    def reset(self):
+        self.sendline('sudo reboot')
+        self.expect(['going down','disconnected'])
+        try:
+            self.expect(self.prompt, timeout=10)
+        except:
+            pass
+        time.sleep(15)  # Wait for the network to go down.
+        for i in range(0, 20):
+            try:
+                pexpect.spawn('ping -w 1 -c 1 ' + self.name).expect('64 bytes', timeout=1)
+            except:
+                print(self.name + " not up yet, after %s seconds." % (i + 15))
+            else:
+                print("%s is back after %s seconds, waiting for network daemons to spawn." % (self.name, i + 14))
+                time.sleep(15)
+                break
+        self.__init__(self.name, self.color,
+                      self.output, self.username,
+                      self.password, self.port,
+                      reboot=False)
+
+    def get_ip_addr(self, interface):
+        self.sendline("\nifconfig %s" % interface)
+        self.expect('addr:(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}).*(Bcast|P-t-P):', timeout=5)
+        ipaddr = self.match.group(1)
+        self.expect(self.prompt)
+        return ipaddr
+
+    def ip_neigh_flush(self):
+        self.sendline('\nsudo ip_neigh_flush')
+        self.expect('flush all')
+        self.expect(self.prompt)
+
+    def turn_on_pppoe(self):
+        self.sendline('sudo turn_on_pppoe')
+        self.expect(self.prompt)
+
+    def turn_off_pppoe(self):
+        pass
+
+    def restart_tftp_server(self):
+        self.sendline('\nsudo restart_tftp_server')
+        self.expect('Restarting')
+        self.expect(self.prompt)
+
+    def configure(self, kind):
+        if kind == "wan_device":
+            self.setup_as_wan_gateway()
+        elif kind == "lan_device":
+            self.setup_as_lan_device()
+
+    def setup_as_wan_gateway(self):
+        self.sendline('\necho "needs to be setup via root. If not setup, this is bad."')
+
+    def setup_as_lan_device(self):
+        self.sendline('\necho "needs to be setup via root. If not setup, this is bad"')
+
+    def start_lan_client(self):
+        self.sendline('\nsudo start_lan_client')
+        self.expect(self.prompt)

--- a/prepare_for_nonroot
+++ b/prepare_for_nonroot
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+import argparse
+import re
+import sys
+import pexpect
+import os
+import tempfile
+import shutil
+
+from devices import base
+
+from termcolor import colored, cprint
+
+GET_STARTED = '''
+This program prepares a system to run as a LAN or WAN system
+with the tests run as a non-root user. This script is idempotent, i.e. if your
+run it multiple times, it won't cause any problems.
+
+If you've set the '-p' argument, we'll ask you whether you want particular
+changes made to your system. In almost all cases, you should answer 'y'.
+'''
+
+ADD_CRON_DHCLIENT = '''
+If you set the IP address for eth0 via dhclient, boardfarm will likely
+cause the DHCP lease to not be renewed. This settings adds a cron job to
+check if dhclient for eth0 is running and, if not, restart it.
+'''
+
+ADD_STARTUP = '''
+To get the system in a standard state, boardfarm can run some preparation
+scripts at startup.
+'''
+
+SET_CHMODS = '''
+We need to have some executables available to non-root users. These are mostly
+executables related to the network. Some executables include 'ping', 'ip',
+'xtables-multi' (for firewalls) and 'ifconfig'
+'''
+
+SUDOERS_HELP = '''
+Some commands must be run as root but we'd rather they be run via sudo. To make
+this possible, we add the testing user to a sudoers file.
+'''
+
+LINKS_FOR_BIN = '''
+Boardfarm expects that some scripts files will be in an expected location. These
+locations are the same as the ones added in the sudoers file.
+'''
+
+class SetupDevice(base.BaseDevice):
+    prompt = ['.+\\@.*:.*(\$|#)']
+    def __init__(self):
+        pexpect.spawn.__init__(self, command="bash")
+        self.color = "blue"
+        cprint("device console = %s" % colored(self.color, self.color), None, attrs=['bold'])
+        self.logfile_read = sys.stdout
+
+    #we default to bin subdir
+class SetupRunner(object):
+
+    def __init__(self, username, type, test=True, show_prompts=False):
+        self.device = SetupDevice()
+        self.type = type
+        self.username = username
+        self.test = test
+        self.show_prompts = show_prompts
+
+    def add_to_sudoers(self, template_file=None):
+        if self.notify_and_ask_for_permission(SUDOERS_HELP):
+            if template_file is None:
+                template_file = self.local_file('conf', 'testing_sudoers')
+            f = open(template_file, 'rb')
+            lines = f.readlines()
+            f.close()
+
+            testing_cmds_to_tester_regexp = "^__username__"
+            testing_cmds_to_tester_contents = "%s ALL=(ALL) NOPASSWD: TESTING_CMDS" % self.username
+            self.replace_or_add_line(lines, testing_cmds_to_tester_regexp, testing_cmds_to_tester_contents)
+            self.save_sudoers(lines)
+
+    #inspired from Ansible but not enough to influence copyright
+    def replace_or_add_line(self, lines, regex, line_to_make_present):
+        line_num = -1
+        mre = re.compile(regex)
+        for lineno, cur_line in enumerate(lines):
+            match_found = mre.search(cur_line)
+            if match_found:
+                line_num = lineno
+        if line_num != -1:
+            lines[line_num] = line_to_make_present
+        else:
+            if len(lines)>0 and not (lines[-1].endswith('\n') or lines[-1].endswith('\r')):
+                lines.append(os.linesep)
+            lines.append(line_to_make_present + os.linesep)
+
+    def save_sudoers(self, lines):
+        fd, path = tempfile.mkstemp()
+        f = os.fdopen(fd, 'w+b')
+        f.writelines(lines)
+        f.close();
+        write_to_path = "/etc/sudoers.d/testing_sudoers"
+        self.device.sendline("visudo -c -f " + path)
+        self.device.expect(path + ': parsed OK')
+        if self.test:
+            print("\n" + "atomic rename of %s to %s" % (path, write_to_path))
+        if not(self.test):
+            #atomic rename
+            os.rename(path, write_to_path)
+
+    def add_links_for_bins(self):
+        if self.notify_and_ask_for_permission(LINKS_FOR_BIN):
+            bin_str = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'bin')
+            bins = [ f for f in os.listdir(bin_str) if not(f.endswith('.sh')) ]
+            for f in bins:
+                bin_file = os.path.join(bin_str, f)
+                command = "ln -fs %s /usr/bin/%s" % (bin_file, f)
+                if self.test:
+                    print("\n" + command)
+                else:
+                    self.device.sendline(command)
+                    self.device.expect(SetupDevice.prompt)
+
+    def set_chmods(self):
+        if self.notify_and_ask_for_permission(SET_CHMODS):
+            for f in ["/bin/ip", "/bin/ping", "/bin/ping6", "/sbin/xtables-multi", "/sbin/ifconfig"]:
+                command = "chmod 4755 %s" % f
+                if self.test:
+                    print("\n" + command)
+                else:
+                    self.device.sendline(command)
+                    self.device.expect(SetupDevice.prompt)
+
+    def local_file(self, *path_parts):
+        '''Calculates the absolute path from path_parts relative to the boardfarm
+        directory'''
+        return os.path.join(os.path.dirname(os.path.abspath(__file__)),*path_parts)
+
+    def add_to_startup(self):
+        if self.notify_and_ask_for_permission(ADD_STARTUP):
+            service_file = None
+            filename = None
+            if self.type == 'lan':
+                filename = 'lan_setup.service'
+            elif self.type == 'wan':
+                filename = 'wan_setup.service'
+            else:
+                print("\nmust be lan or wan")
+                sys.exit(1)
+
+            service_file = self.local_file('conf', filename)
+
+            lines = ["cp -f %s /etc/systemd/system/%s" % (service_file, filename),
+                    "systemctl daemon-reload",
+                    'systemctl enable %s' % filename ]
+            if self.test:
+                for f in lines:
+                    print("\n" + f)
+            else:
+                for f in lines:
+                    self.device.sendline(f)
+                    self.device.expect(SetupDevice.prompt)
+
+    def setup_cron_for_dhclient_eth0(self):
+        if self.notify_and_ask_for_permission(ADD_CRON_DHCLIENT):
+            lines = ["cp -f %s /etc/systemd/system/%s" % (self.local_file("conf", 'dhclient.eth0.service'), 'dhclient.eth0.service'),
+                        'systemctl daemon-reload',
+                        'systemctl enable %s' % 'dhclient.eth0.service',
+                        "ln -fs %s /etc/cron.d/boardfarm" % self.local_file("conf", 'boardfarm_cron')]
+            if self.test:
+                for f in lines:
+                    print("\n" + f)
+            else:
+                for f in lines:
+                    self.device.sendline(f)
+                    self.device.expect(SetupDevice.prompt)
+
+
+    def check_if_root(self):
+        self.device.sendline("id -u")
+        try:
+            self.device.expect('\n0\r\n')
+        except:
+            print("\nThis program must be running as root. Try running with 'sudo'\n")
+            sys.exit(1)
+
+    def notify_and_ask_for_permission(self, notification):
+        response = "[Y|n]: "
+        while True:
+            print("\n" + notification + '\n')
+            if not(self.show_prompts):
+                print ('\n' + response + "y\n")
+                return True
+            key = raw_input(response)
+
+            if key.isspace() or key == "" or  key.lower() == 'y':
+                return True
+            elif key.lower() == 'n':
+                return False
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prepare to run this device as non-root',
+                                     usage='prepare_for_non_root type [options...]',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("type", choices=['lan', 'wan'], help="Set this device up as a LAN or WAN device")
+    parser.add_argument('-u', '--user', metavar='', type=str, default='tester', help='Non-root user who will run your boardfarm tests. Default is "tester". This user should be created before your run this test.')
+    parser.add_argument('-p', '--show_prompts', action='store_true', help='Show the prompts to have more granular control')
+    parser.add_argument('-t', '--run_test', action='store_true', help="Run a command as a test (development only)");
+
+    args = parser.parse_args()
+
+    runner = SetupRunner(username=args.user, type=args.type, test=args.run_test, show_prompts=args.show_prompts)
+    print(GET_STARTED)
+
+    runner.check_if_root()
+
+    runner.add_to_sudoers()
+
+    runner.add_links_for_bins()
+
+    runner.set_chmods()
+
+    runner.add_to_startup()
+    runner.setup_cron_for_dhclient_eth0()


### PR DESCRIPTION
This commit provides the ability for board farm administrator to have tests run on a lan and wan device using a non-root user. To actually do so, an administrator would do the following:
## Create a test user with password on the lan and wan devices

I have a user named "tester" with the password "test"
## Clone the boardfarm git repo to your LAN and WAN devices

We need some scripts to run directly on the LAN and WAN devices. To do this, we clone the boardfarm git repo to our LAN/WAN device. I actually clone it via sudo into /opt/boardfarm. 
## Run `prepare_for_nonroot` on the LAN and WAN devices

`prepare_for_nonroot` gets the system into a state where it can function as a lan or wan device with tests running as a nonroot user. `prepare_for_nonroot`'s command line works as follows.

`prepare_for_nonroot lan|wan --user test_user_name`

If you don't have --user in the argument list, it defaults to tester.
## Reboot the LAN and WAN computers
## Add the LAN and WAN username and password to your json config

bft knows that if you provide a username other than root that you are running the tests as non-root and adjusts accordingly. 
## Run bft like normal

I'll add this to documentation once I get approval from folks but this is a big enough change that I'd like to get a once over from some other team members. Any thoughts @miska @mattsm @mbanders?
