### PR TITLE
changed '.' in log field name for Elasticsearch 2.x compatibility

### DIFF
--- a/bft
+++ b/bft
@@ -215,9 +215,9 @@ def main():
         else:
             n = t.__class__.__name__
         for k, v in t.logged.items():
-            info_for_remote_log[n + '.' + k] = v
+            info_for_remote_log[n + '-' + k] = v
         if hasattr(t, 'result_grade'):
-            info_for_remote_log[n + ".result"] = t.result_grade
+            info_for_remote_log[n + "-result"] = t.result_grade
 
     try:
         if config.logging_server is not None:


### PR DESCRIPTION
Elasticsearch 2.x doesn't support dots in field names ([as written here](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#_field_names_may_not_contain_dots)).
Thus, I changed the dots in the field names to dashes.

Signed-off-by: Markus Renken z0n@128bit.org
