### PR TITLE
Make KernelModules safer, us check_output and re

### DIFF
--- a/tests/lsmod.py
+++ b/tests/lsmod.py
@@ -5,18 +5,16 @@
 # This file is distributed under the Clear BSD license.
 # The full text can be found in LICENSE in the root directory.
 
+import re
 import rootfs_boot
 from devices import board, wan, lan, wlan, prompt
 
 class KernelModules(rootfs_boot.RootFSBootTest):
     '''lsmod shows loaded kernel modules.'''
     def runTest(self):
-        board.sendline('\nlsmod | wc -l')
-        board.expect('lsmod ')
-        board.expect('(\d+)\r\n')
-        num = int(board.match.group(1)) - 1 # subtract header line
-        board.expect(prompt)
-        board.sendline('lsmod | sort')
-        board.expect(prompt)
+        board.check_output('lsmod | wc -l')
+        tmp = re.search('\d+', board.before)
+        num = int(tmp.group(0)) - 1 # subtract header line
+        board.check_output('lsmod | sort')
         self.result_message = '%s kernel modules are loaded.' % num
         self.logged['num_loaded'] = num


### PR DESCRIPTION
The `check_output` puts the output of that command into
`board.before` where you can use the regular expression
library `re` to safely search the output.

Signed-off-by: Mike Anderson mbanderson@uwalumni.com
