### PR TITLE
Add support for SSH connection

### DIFF
--- a/bft
+++ b/bft
@@ -123,6 +123,7 @@ def main():
                                                  tftp_username=config.board.get('wan_username', 'root'),
                                                  tftp_password=config.board.get('wan_password', 'bigfoot1'),
                                                  connection_type=config.board.get('connection_type', None),
+                                                 key_password=config.board.get('key_password', None),
                                                  power_username=config.board.get('power_username', None),
                                                  power_password=config.board.get('power_password', None))
             print_bold("dut device console = %s" % colored("black", 'grey'))

--- a/bft
+++ b/bft
@@ -123,7 +123,7 @@ def main():
                                                  tftp_username=config.board.get('wan_username', 'root'),
                                                  tftp_password=config.board.get('wan_password', 'bigfoot1'),
                                                  connection_type=config.board.get('connection_type', None),
-                                                 key_password=config.board.get('key_password', None),
+                                                 ssh_password=config.board.get('ssh_password', None),
                                                  power_username=config.board.get('power_username', None),
                                                  power_password=config.board.get('power_password', None))
             print_bold("dut device console = %s" % colored("black", 'grey'))

--- a/devices/connection_decider.py
+++ b/devices/connection_decider.py
@@ -1,5 +1,6 @@
 import ser2net_connection
 import local_serial_connection
+import ssh_connection
 
 def connection(conn_type, device, **kwargs):
     '''
@@ -9,8 +10,10 @@ def connection(conn_type, device, **kwargs):
         return ser2net_connection.Ser2NetConnection(device=device,**kwargs)
 
     if conn_type in ("local_serial"):
-
         return local_serial_connection.LocalSerialConnection(device=device,**kwargs)
+
+    if conn_type in ("ssh"):
+        return ssh_connection.SshConnection(device=device, **kwargs)
 
     # Default for all other models
     print("\nWARNING: Unknown connection type  '%s'." % type)

--- a/devices/ssh_connection.py
+++ b/devices/ssh_connection.py
@@ -1,0 +1,30 @@
+import pexpect
+
+
+class SshConnection:
+    '''
+        To use, set conn_cmd in your json to "ssh root@192.168.1.1 -i ~/.ssh/id_router_key""
+        and set connection_type to "ssh"
+
+        '''
+    def __init__(self, device=None, conn_cmd=None, key_password='None', **kwargs):
+        self.device = device
+        self.conn_cmd = conn_cmd
+        self.key_password = key_password
+
+    def connect(self):
+        pexpect.spawn.__init__(self.device,
+                               command='/bin/bash',
+                               args=['-c', self.conn_cmd])
+
+        try:
+            result = self.device.expect(["assword:", "passphrase"])
+        except pexpect.EOF as e:
+            raise Exception("Board is in use (connection refused).")
+        if result == 0 or result == 1:
+            self.device.sendline(self.key_password)
+            prompt = ['root\\@.*:.*#', '/ # ', '@R7500:/# ']
+            self.device.expect(prompt)
+
+    def close(self):
+        self.device.sendline('exit')

--- a/devices/ssh_connection.py
+++ b/devices/ssh_connection.py
@@ -3,14 +3,14 @@ import pexpect
 
 class SshConnection:
     '''
-        To use, set conn_cmd in your json to "ssh root@192.168.1.1 -i ~/.ssh/id_router_key""
+        To use, set conn_cmd in your json to "ssh root@192.168.1.1 -i ~/.ssh/id_rsa""
         and set connection_type to "ssh"
 
         '''
-    def __init__(self, device=None, conn_cmd=None, key_password='None', **kwargs):
+    def __init__(self, device=None, conn_cmd=None, ssh_password='None', **kwargs):
         self.device = device
         self.conn_cmd = conn_cmd
-        self.key_password = key_password
+        self.ssh_password = ssh_password
 
     def connect(self):
         pexpect.spawn.__init__(self.device,
@@ -18,13 +18,13 @@ class SshConnection:
                                args=['-c', self.conn_cmd])
 
         try:
-            result = self.device.expect(["assword:", "passphrase"])
+            result = self.device.expect(["assword:", "passphrase"] + self.device.prompt)
         except pexpect.EOF as e:
             raise Exception("Board is in use (connection refused).")
         if result == 0 or result == 1:
-            self.device.sendline(self.key_password)
-            prompt = ['root\\@.*:.*#', '/ # ', '@R7500:/# ']
-            self.device.expect(prompt)
+            assert self.ssh_password is not None, "Please add ssh_password in your json configuration file."
+            self.device.sendline(self.ssh_password)
+            self.device.expect(self.device.prompt)
 
     def close(self):
         self.device.sendline('exit')


### PR DESCRIPTION
Sometimes there is a need to run tests on production board with serial disabled.

Added possibility to connect to the tested board with ssh. Authentication
can be done with password, ssh key without password or ssh password
protected key. To use ssh connection you need json config file properties:
'connection_type': 'ssh',
'ssh_password': <password>,